### PR TITLE
Externalise styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 typings
 dist
-lib/**/*.css
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,18 @@
+# IDE settings
+.vscode
+.idea
+
+# dev-only and irrelevant files
+.npmignore
+tsconfig*.json
+tslint.json
+.editorconfig
+demo
+config
 typings
 node_modules
+
+# typescript sources
+*.ts
+# leave typings intact for AoT purposes
+!*.d.ts

--- a/lib/components/tag-input-autocomplete/tag-input-autocomplete.component.ts
+++ b/lib/components/tag-input-autocomplete/tag-input-autocomplete.component.ts
@@ -17,13 +17,9 @@ import { KEYS } from '../../shared/tag-input-keys';
   `,
   styles: [`
     :host {
-      box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
       display: block;
       position: absolute;
       top: 100%;
-      font-family: "Roboto", "Helvetica Neue", sans-serif;
-      font-size: 16px;
-      color: #444444;
       background: white;
       padding: 8px 0;
     }
@@ -32,10 +28,6 @@ import { KEYS } from '../../shared/tag-input-keys';
       padding: 0 16px;
       height: 48px;
       line-height: 48px;
-    }
-
-     :host .is-selected {
-      background: #eeeeee;
     }
   `]
 })

--- a/lib/components/tag-input-item/tag-input-item.component.ts
+++ b/lib/components/tag-input-item/tag-input-item.component.ts
@@ -10,41 +10,28 @@ import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/co
   `,
   styles: [`
     :host {
-      font-family: "Roboto", "Helvetica Neue", sans-serif;
-      font-size: 16px;
       height: 32px;
       line-height: 32px;
       display: inline-block;
-      background: #e0e0e0;
       padding: 0 12px;
       border-radius: 90px;
       margin-right: 10px;
-      transition: all 0.12s ease-out;
+    }
+    
+    :host.ng2-tag-input-item-selected {
+      background: #0d8bff;
     }
 
      :host .ng2-tag-input-remove {
-      background: #a6a6a6;
       border-radius: 50%;
-      color: #e0e0e0;
       cursor: pointer;
       display: inline-block;
-      font-size: 17px;
       height: 24px;
       line-height: 24px;
       margin-left: 6px;
       margin-right: -6px;
       text-align: center;
       width: 24px;
-    }
-
-    :host.ng2-tag-input-item-selected {
-      color: white;
-      background: #0d8bff;
-    }
-
-     :host.ng2-tag-input-item-selected .ng2-tag-input-remove {
-      background: white;
-      color: #0d8bff;
     }
   `]
 })

--- a/lib/components/tag-input/tag-input.component.ts
+++ b/lib/components/tag-input/tag-input.component.ts
@@ -61,13 +61,8 @@ export interface AutoCompleteItem {
   `,
   styles: [`
     :host {
-      font-family: "Roboto", "Helvetica Neue", sans-serif;
-      font-size: 16px;
       display: block;
-      box-shadow: 0 1px #ccc;
       padding: 8px 0 6px 0;
-      will-change: box-shadow;
-      transition: box-shadow 0.12s ease-out;
     }
 
      :host .ng2-tag-input-form {
@@ -75,8 +70,6 @@ export interface AutoCompleteItem {
     }
 
      :host .ng2-tag-input-field {
-      font-family: "Roboto", "Helvetica Neue", sans-serif;
-      font-size: 16px;
       display: inline-block;
       width: auto;
       box-shadow: none;
@@ -91,10 +84,6 @@ export interface AutoCompleteItem {
      :host .rl-tag-input-autocomplete-container {
       position: relative;
       z-index: 10;
-    }
-
-    :host.ng2-tag-input-focus {
-      box-shadow: 0 2px #0d8bff;
     }
   `],
   providers: [

--- a/lib/components/tag-input/tag-input.component.ts
+++ b/lib/components/tag-input/tag-input.component.ts
@@ -314,6 +314,8 @@ export class TagInputComponent implements ControlValueAccessor, OnDestroy, OnIni
   }
 
   ngOnDestroy() {
-    this.tagInputSubscription.unsubscribe();
+    if (this.tagInputSubscription) {
+      this.tagInputSubscription.unsubscribe();
+    }
   }
 }

--- a/lib/tag-input.css
+++ b/lib/tag-input.css
@@ -14,3 +14,36 @@ rl-tag-input .ng2-tag-input-field {
 rl-tag-input.ng2-tag-input-focus {
     box-shadow: 0 2px #0d8bff;
 }
+
+rl-tag-input-autocomplete {
+     box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+     font-family: "Roboto", "Helvetica Neue", sans-serif;
+     font-size: 16px;
+     color: #444444;
+ }
+
+rl-tag-input-autocomplete .is-selected {
+    background: #eeeeee;
+}
+
+rl-tag-input-item {
+    font-family: "Roboto", "Helvetica Neue", sans-serif;
+    font-size: 16px;
+    background: #e0e0e0;
+    transition: all 0.12s ease-out;
+}
+
+rl-tag-input-item .ng2-tag-input-remove {
+    background: #a6a6a6;
+    color: #e0e0e0;
+    font-size: 17px;
+}
+
+rl-tag-input-item.ng2-tag-input-item-selected {
+    color: white;
+}
+
+rl-tag-input-item.ng2-tag-input-item-selected .ng2-tag-input-remove {
+    background: white;
+    color: #0d8bff;
+}

--- a/lib/tag-input.css
+++ b/lib/tag-input.css
@@ -1,0 +1,16 @@
+rl-tag-input {
+    font-family: "Roboto", "Helvetica Neue", sans-serif;
+    font-size: 16px;
+    box-shadow: 0 1px #ccc;
+    will-change: box-shadow;
+    transition: box-shadow 0.12s ease-out;
+}
+
+rl-tag-input .ng2-tag-input-field {
+    font-family: "Roboto", "Helvetica Neue", sans-serif;
+    font-size: 16px;
+}
+
+rl-tag-input.ng2-tag-input-focus {
+    box-shadow: 0 2px #0d8bff;
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "angular2-tag-input",
   "version": "1.2.3",
   "description": "Tag input component for Angular 2",
+  "typings": "dist/index.d.ts",
   "main": "dist/index.js",
   "keywords": [
     "angular2",


### PR DESCRIPTION
Pull non-layout styles out of components into stylesheet. Therefore stylesheet can be optionally included or components can be styled with user style rules.